### PR TITLE
CalVer patterns support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Suitable format for the tag is dependent on [Configuration/Tag Pattern](#tag-pat
 
 ### 1. Configure the plugin
 
-Simply add the plugin to your `:plugins` vector:
+Add the plugin to your `:plugins` vector:
 ```clojure
 :plugins [[fi.polycode/lein-git-revisions "LATEST"]
           ...]
@@ -153,6 +153,7 @@ or define your own:
 ```
 
  - `:semver` is built-in configuration set for the [Semantic Versioning](https://semver.org/) scheme.
+ - `:commit-hash` is built-in configuration for using Git commit hash as-is as the version string.
 
 ##### Tag Pattern (`:tag-pattern`)
 

--- a/README.md
+++ b/README.md
@@ -123,9 +123,11 @@ example `:env/user` looks up the value of environment variable `USER`.
  - `:rev/*` Lookup a value from [Tag pattern](#tag-pattern-tag-pattern) based on named capture group
  - `:git/*` Properties matching the current Git state, such as previous tag, versioning status, ahead/dirty...
  - `:constants/*` See [Common constants](#common-constants-constants)
- - `:gen/*` Miscellanous values generated during runtime
  - `:calver/*` Support [Calendar Versioning](https://calver.org/) patterns. Note that due to Clojure keyword limitations
    the zero-padding patterns are flipped, so `0M` is `:calver/m0` and so on.
+ - `:dt/*` Common datetime parts, from current year to current second.
+
+More in-depth documentation for lookups is available in [Available Lookups](docs/lookups.md).
 
 ### Full configuration
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,6 @@
 # lein-git-revisions
 
-**Latest:**
-
 [![Deploy to Clojars](https://github.com/esuomi/lein-git-revisions/actions/workflows/deploy.yaml/badge.svg)](https://github.com/esuomi/lein-git-revisions/actions/workflows/deploy.yaml)
-![Clojars Version (including pre-releases)](https://img.shields.io/clojars/v/fi.polycode/lein-git-revisions?include_prereleases)
-[![cljdoc badge](https://cljdoc.org/badge/fi.polycode/lein-git-revisions)](https://cljdoc.org/jump/release/fi.polycode/lein-git-revisions)
-
-**Stable:**
-
-[![Deploy to Clojars](https://github.com/esuomi/lein-git-revisions/actions/workflows/release.yaml/badge.svg)](https://github.com/esuomi/lein-git-revisions/actions/workflows/release.yaml)
 ![Clojars Version (including pre-releases)](https://img.shields.io/clojars/v/fi.polycode/lein-git-revisions)
 [![cljdoc badge](https://cljdoc.org/badge/fi.polycode/lein-git-revisions)](https://cljdoc.org/jump/release/fi.polycode/lein-git-revisions)
 

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -1,0 +1,36 @@
+# Built-in formats
+
+Built-in patterns are complete, readymade and opinionated sets of configurations which implement a specific revisioning
+pattern. They are meant to be quick-to-start patterns
+
+To use any built-in pattern, define plugin configuration's `:format` key as keyword matching to desired built-in:
+```clojure
+:git-revisions {:format :built-in-format-identifier}
+```
+
+## Semantic Versioning (`:semver`)
+
+```clojure
+:git-revisions {:format :semver
+                :adjust [:env/lein_revisions_adjustment :minor]}
+```
+
+Pattern which follows [Semantic Versioning](semver.org/). Most people know this as "Maven pattern", or "Aether pattern"
+or just "the three dotted numbers" pattern.
+
+The format supports adjusting the resulting pattern with either `:major`, `:minor` or `:patch` qualifiers.
+
+The format also has fallbacks for unversioned and unreleased projects, producing such revision patterns as
+`UNKNOWN-UNVERSIONED` and `UNKNOWN-SNAPSHOT` based on active context.
+
+Git tags are expected to be in format `vX.Y.Z`, where X, Y and Z are all positive integers.
+
+## Commit hash (`:commit-hash`)
+
+```clojure
+:git-revisions {:format :commit-hash}
+```
+
+Use current commit's full SHA-1 as revision string as-is.
+
+Has a fallback for unversioned projects, in which case the revision string is `UNKNOWN`.

--- a/docs/lookups.md
+++ b/docs/lookups.md
@@ -1,0 +1,72 @@
+# Available Lookups
+
+> See also project tests for examples
+
+## Environment variables (`:env/*`)
+
+Environment variable lookup. Key is uppercased but otherwise untouched; remember to use underscores as word
+delimiter.
+
+Available values are dependent on what the JVM process sees and cannot be altered during runtime.
+
+```clojure
+{:format {:pattern [:segment/always [:env/lein_username]]}}  ; will lookup environment variable LEIN_USERNAME
+;=> "esuomi"
+```
+
+## Revision metadata (`:rev/*`)
+
+`:rev/*` Lookup a value from [Tag pattern](../README.md#tag-pattern-tag-pattern) based on named capture group.
+
+This lookup is dynamic and entirely dependent on the provided regular expression. There's no caching and values in the
+pattern are not guaranteed to be extracted if not used.
+
+```clojure
+{:format {:tag-pattern #"(?<suffix>.{,3}).+$"
+          :pattern [:segment/always [:rev/suffix]]}}  ; up to three first characters of matching Git tag
+;=> "v3." (for tag v3.1.0)
+```
+
+## Git metadata (`:git/*`)
+
+Values matching the current Git state, such as previous tag, versioning status, ahead/dirty...
+
+Values ending in question mark are meant to be used like predicates and are guaranteed to be booleans.
+
+Always available:
+
+ - `:git/unversioned?` is version control enabled?
+ - `:git/untagged?` does a suitable - if any - Git tag exist? Usually this means no tags available, see [Prerequisites](../README.md#0-prerequisites)
+
+Conditionally available:
+ -
+ - `:git/ref` Current commit's reference hash, implementation specific on used Git version and configuration, most likely SHA-1
+ - `:git/ref-short` Short hash of the current commit
+ - `:git/dirty?` Working tree has local modifications
+ - `:git/ahead?` Is current HEAD ahead of its upstream
+ - `:git/ahead` How many commits ahead the current HEAD is
+ - `:git/tag` Latest known visible tag which matches the [Tag pattern](../README.md#tag-pattern-tag-pattern)
+ - `:git/branch` Name of current branch
+
+## Common Constants (`:constants/*`)
+
+Mechanism for piggybacking constant values from build to the revision resolution process. See [Common constants](#common-constants-constants)
+
+## Calendar versioning schemes (`:calver/*`)
+
+Support for looking up [Calendar Versioning](https://calver.org/) schemes. Note that due to Clojure keyword limitations
+  the zero-padding patterns are flipped, so `0M` is `:calver/m0` and so on.
+
+As CalVer is not a stabilized specification but a just a set of common schemes, there's a near-infinite amount of
+combinations that could be used with tag patterns and outputs.
+
+## Datetime parts (`:dt/*`)
+
+Common datetime parts, from current year to current second. All in singular form.
+
+ - `:dt/year`
+ - `:dt/month`
+ - `:dt/day`
+ - `:dt/hour`
+ - `:dt/minute`
+ - `:dt/second`

--- a/project.clj
+++ b/project.clj
@@ -15,6 +15,8 @@
                                     :username      :env/CLOJARS_USERNAME
                                     :password      :env/CLOJARS_TOKEN}]]
 
+  :global-vars {*warn-on-reflection* true}
+
   :plugins [[fi.polycode/lein-git-revisions "LATEST"]
             [lein-pprint "1.3.2"]]
 

--- a/src/lein_git_revisions/plugin.clj
+++ b/src/lein_git_revisions/plugin.clj
@@ -52,13 +52,6 @@
   (when (= "env" (namespace part))
     (System/getenv (str/upper-case (name part)))))
 
-(defn lookup-gen
-  "Generates a dynamic value for supported lookup `parts`."
-  [part]
-  (when (= "gen" (namespace part))
-    (case (name part)
-      "timestamp" "2022-02-22")))
-
 (defn- lookup-group
   "Returns a `part` `lookup function` using the provided [java.util.regex.Matcher][Matcher] as a backing source for
    the values.
@@ -170,7 +163,6 @@
   (let [git (merge git
                    {:unversioned? (nil? git)}
                    {:untagged?    (nil? tag)})
-
         {:keys [tag-pattern pattern constants adjustments] :as config}
         (cond (keyword? format) (get predefined-formats format)
               (map? format)     format) ; TODO: else "unsupported format <blaa>"
@@ -180,7 +172,6 @@
                                       (lookup-group (re-matcher (or tag-pattern #"$^") (or tag "")))
                                       lookup-calver
                                       lookup-datetime
-                                      lookup-gen
                                       lookup-env)
         adjustments          (create-adjustments adjustments lookup adjust)
         into-version-segment (resolve-and-adjust lookup adjustments)]

--- a/test/lein_git_revisions/plugin_tests.clj
+++ b/test/lein_git_revisions/plugin_tests.clj
@@ -1,14 +1,16 @@
 (ns lein-git-revisions.plugin-tests
   (:require [clojure.test :refer :all]
             [lein-git-revisions.plugin :as plugin])
-  (:import (java.time Clock LocalDate ZoneId)))
+  (:import (java.time Clock LocalDate ZoneId LocalDateTime)))
 
 (defn- fix-clock-to
-  [^long y ^long m ^long d]
-  (Clock/fixed (-> (LocalDate/of y m d)
-                   (.atStartOfDay (ZoneId/systemDefault))
-                   .toInstant)
-               (ZoneId/systemDefault)))
+  ([^Long y ^Long m ^Long d]
+   (fix-clock-to y m d 0 0 0))
+  ([^Long y ^Long m ^Long d ^Long h ^Long mm ^Long s]
+   (let [dt (LocalDateTime/of y m d h mm s)
+         zo (-> (ZoneId/systemDefault) .getRules (.getOffset dt))]
+     (Clock/fixed (.toInstant dt zo)
+                  (ZoneId/systemDefault)))))
 
 (deftest calver-lookup-formatting
   (testing "Patterns for early 21st century date"
@@ -33,4 +35,22 @@
       (is (= "46" (plugin/lookup-calver :calver/ww)))
       (is (= "46" (plugin/lookup-calver :calver/w0)))
       (is (= "16" (plugin/lookup-calver :calver/dd)))
-      (is (= "16" (plugin/lookup-calver :calver/d0))))))
+      (is (= "16" (plugin/lookup-calver :calver/d0)))))
+
+  (testing "all supported patterns can be used in format"
+    (with-bindings {#'plugin/*clock* (fix-clock-to 2022 11 3 7 44 55)}
+      (is (= "2022-22-22-11-11-44-44-3-03" (plugin/revision-generator {} {:pattern [:segment/always [:calver/yyyy "-" :calver/yy "-" :calver/y0 "-" :calver/mm "-" :calver/m0 "-" :calver/ww "-" :calver/w0 "-" :calver/dd "-" :calver/d0]]} nil))))))
+
+(deftest datetime-lookup
+  (testing "Most common datetime parts are supported"
+    (with-bindings {#'plugin/*clock* (fix-clock-to 1991 8 24)}
+      (is (= "1991" (plugin/lookup-datetime :dt/year)))
+      (is (= "8" (plugin/lookup-datetime :dt/month)))
+      (is (= "24" (plugin/lookup-datetime :dt/day)))
+      (is (= "0" (plugin/lookup-datetime :dt/hour)))
+      (is (= "0" (plugin/lookup-datetime :dt/minute)))
+      (is (= "0" (plugin/lookup-datetime :dt/second)))))
+
+  (testing "all supported patterns can be used in format"
+    (with-bindings {#'plugin/*clock* (fix-clock-to 1985 10 16 6 12 0)}
+      (is (= "1985.10.16T6.12.0Z" (plugin/revision-generator {} {:pattern [:segment/always [:dt/year "." :dt/month "." :dt/day "T" :dt/hour "." :dt/minute "." :dt/second "Z"]]} nil))))))

--- a/test/lein_git_revisions/plugin_tests.clj
+++ b/test/lein_git_revisions/plugin_tests.clj
@@ -1,0 +1,36 @@
+(ns lein-git-revisions.plugin-tests
+  (:require [clojure.test :refer :all]
+            [lein-git-revisions.plugin :as plugin])
+  (:import (java.time Clock LocalDate ZoneId)))
+
+(defn- fix-clock-to
+  [^long y ^long m ^long d]
+  (Clock/fixed (-> (LocalDate/of y m d)
+                   (.atStartOfDay (ZoneId/systemDefault))
+                   .toInstant)
+               (ZoneId/systemDefault)))
+
+(deftest calver-lookup-formatting
+  (testing "Patterns for early 21st century date"
+    (with-bindings {#'plugin/*clock* (fix-clock-to 2006 2 9)}
+      (is (= "2006" (plugin/lookup-calver :calver/yyyy)))
+      (is (= "6" (plugin/lookup-calver :calver/yy)))
+      (is (= "06" (plugin/lookup-calver :calver/y0)))
+      (is (= "2" (plugin/lookup-calver :calver/mm)))
+      (is (= "02" (plugin/lookup-calver :calver/m0)))
+      (is (= "6" (plugin/lookup-calver :calver/ww)))
+      (is (= "06" (plugin/lookup-calver :calver/w0)))
+      (is (= "9" (plugin/lookup-calver :calver/dd)))
+      (is (= "09" (plugin/lookup-calver :calver/d0)))))
+
+  (testing "Patterns for mid-21st century date"
+    (with-bindings {#'plugin/*clock* (fix-clock-to 2168 11 16)}
+      (is (= "2168" (plugin/lookup-calver :calver/yyyy)))
+      (is (= "168" (plugin/lookup-calver :calver/yy)))
+      (is (= "168" (plugin/lookup-calver :calver/y0)))
+      (is (= "11" (plugin/lookup-calver :calver/mm)))
+      (is (= "11" (plugin/lookup-calver :calver/m0)))
+      (is (= "46" (plugin/lookup-calver :calver/ww)))
+      (is (= "46" (plugin/lookup-calver :calver/w0)))
+      (is (= "16" (plugin/lookup-calver :calver/dd)))
+      (is (= "16" (plugin/lookup-calver :calver/d0))))))


### PR DESCRIPTION
Adds support for [Calendar Versioning](https://calver.org/) lookups and also includes some polishing here and there.

TODO:

 - [x] Generic datetime lookup as well, as discussed in the issue #6 
 - [x] Improved documentation for CalVer itself, especially since `:semver` is currently so prominent across the entire readme 

Fixes #6 